### PR TITLE
Fix typos in Neovim config comments

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -83,7 +83,7 @@ vim.keymap.set('n', '<leader>yd', function()
   vim.notify('Yanked ' .. #diagnostics .. ' diagnostic messages', vim.log.levels.INFO)
 end, { desc = '[y]ank [d]iagnostics messages under cursor' })
 
--- This keymap is useful for testing and debugging condiions
+-- This keymap is useful for testing and debugging conditions
 vim.keymap.set('n', '<leader>yx', function()
   local line = vim.api.nvim_get_current_line()
   local row = vim.api.nvim_win_get_cursor(0)[1]

--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -66,7 +66,7 @@ vim.o.scrolloff = 8
 
 vim.g.netrw_banner = 0
 
--- Triger `autoread` when files changes on disk
+-- Trigger `autoread` when files changes on disk
 vim.o.autoread = true
 
 -- Highlight when yanking (copying) text


### PR DESCRIPTION
## Summary
- fix typo in options comment
- fix typo in keymaps comment

## Testing
- `grep -n Trigger nvim/lua/config/options.lua`
- `grep -n conditions nvim/lua/config/keymaps.lua`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected typos in comments for improved clarity. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->